### PR TITLE
Fix stuff + add expflags

### DIFF
--- a/app/2015YTm.css
+++ b/app/2015YTm.css
@@ -50,6 +50,8 @@ transition: margin .2s, padding .2s;
     display: none;
 }
 
+.text-selection *:not(input):not(select):not(code):not(textarea):not([contenteditable]) { -webkit-touch-callout: none; -webkit-user-select: none; -khtml-user-select: none; -moz-user-select: none; -ms-user-select: none; user-select: none; }
+
 /* Tab content */
 .tabs-content-container {
     display: flex;
@@ -605,6 +607,9 @@ animation: none;
     width: auto;
     animation: overlay-fade .3s ease-in-out;
 }
+.no-animation .tabs-content-container>.spinner-container {
+    animation: none;
+}
 .spinner-container[hidden] {
 animation-name: fade;
 animation-duration: .28s;
@@ -903,6 +908,10 @@ ytm15-icon>svg {
     box-shadow: none;
 }
 
+.underline button:not(h2):not(.secondary-text):not(.menu-item-button):not(.error-content),.pivot-bar-item-title {
+    text-decoration:underline;
+}
+
 /* Header bar */
 ytm15-header-bar {
     display: flex;
@@ -996,6 +1005,9 @@ ytm15-header-bar[ischannel="true"] {
     flex-shrink: 0;
     display: flex;
     align-items: center;
+}
+.header-no-shadow ytm15-header-bar {
+    box-shadow: none !important;
 }
 
 /* Header logo */
@@ -1143,6 +1155,9 @@ input.searchbox-input {
 .searching-overlay[hidden] {
     animation: overlay-fade-out .2s;
 }
+.searching-overlay {
+    animation: none !important;
+}
 @keyframes overlay-fade {
 0% {
     opacity: 0;
@@ -1190,6 +1205,35 @@ overflow: hidden;
     display: block;
     animation: page-expand-in .2s;
 }
+.no-animations .page-container,.error-container,page.home,.lazy-list,.error-content {
+    animation: none !important;
+}
+.no-animations .ytm15-img.lazy {
+    opacity: 1 !important;
+}
+/*.no-animations .searching-overlay~.page-container>page {
+    display: block;
+    animation: ios-page-slide 0.6s cubic-bezier(0.2, 0.8, 0.2, 1);
+}*/
+.no-animations ytm15-settings.page-visible {
+    animation: ios-page-slide 0.6s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.no-animations ytm15-settings {
+    animation: ios-page-slide 0.6s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.no-animations .settings-categories-container,.settings-pages-container {
+    transition: none !important;
+}
+.no-animations .page-visible .settings-pages-container {
+    display: inherit;
+}
+.no-animations .settings-pages-container {
+    display:none;
+}
+/*.no-animations .page-visible .settings-categories-container {
+      animation: ios-page-slide-left 0.5s cubic-bezier(0.2, 0.8, 0.2, 1);
+}*/
+ytm15-settings.page-visible
 .searching-overlay:not([hidden])~.page-container>page {
     animation: page-expand-out .2s;
     transform: scale(1.1);
@@ -2034,6 +2078,18 @@ h2 {
     font-size: 1.75rem;
 }
 
+.ios-spinner .spinner-container.full-height {
+    height: 76px;
+}
+
+.ios-spinner .spinner .path {
+    stroke: rgba(0,0,0,0.5);
+}
+
+.dark.ios-spinner .spinner .path {
+    stroke: rgba(255, 255, 255, 0.6);
+}
+
 /* Badges */
 ytm15-badge {
     display: inline-block;
@@ -2104,6 +2160,24 @@ ytm15-video-metadata.item:first-child, ytm15-video-metadata.item:last-child {
 }
 100% {
     max-height: 3.5em;
+}
+}
+@keyframes ios-page-slide {
+0% {
+    transform: translateX(100%);
+}
+100% {
+    transform: translateX(0%);
+}
+}
+@keyframes ios-page-slide-left {
+0% {
+    opacity:1;
+    transform: translateX(0%);
+}
+100% {
+    opacity:0;
+    transform: translateX(-100%);
 }
 }
 .video-metadata-title {
@@ -3828,7 +3902,7 @@ ytm15-icon.post-image-icon {
 .shorter-pivot [has-pivot-bar="true"] .tabs-content-container>.spinner-container {
     margin-bottom: 48px;
 }
-html:not(.dark) .pivot-bar-item-tab.has-ripple::before {
+/*html*/:not(.dark) .pivot-bar-item-tab.has-ripple::before {
     background-color: rgba(238, 0, 0, 0.15);
 }
 ytm15-pivot-bar {
@@ -4157,6 +4231,12 @@ label.radio-label {
     display:unset;
     text-align:center;
     margin-top: 10px;
+}
+.tap-to-retry .error-text {
+    font-weight: unset;
+}
+.tap-to-retry .error-container {
+    border-bottom: unset !important;
 }
 @media (min-width: 749px) {
 .tap-to-retry .error-icon {
@@ -5679,6 +5759,15 @@ html.dark {
 .dark [data-viewing-replies="true"]>ytm15-comment {
     background-color: #282828;
 }
+html.dark.seperate-dark-color {
+    background-color: #1D1D1D !important;
+}
+.transparent-text {
+    color:#fff;
+}
+.dark .transparent-text {
+    color:#303030;
+}
 
 /* Dark 28 */
 html.dark.dark-28 {
@@ -5703,6 +5792,46 @@ html.dark.dark-28 {
 }
 .dark.dark-28 [data-viewing-replies="true"]>ytm15-comment {
     background-color: #212121;
+}
+.dark.dark-28 .transparent-text {
+    color:#282828;
+}
+
+/* Dark 25 */
+html.dark.dark-25 {
+    background-color: #252525;
+}
+.dark.dark-25 ytm15-header-bar.non-red:not([ischannel="true"]) {
+    background-color: #252525;
+}
+.dark.dark-25 ytm15-pivot-bar {
+    background-color: #252525;
+}
+.dark.dark-25 .searching-overlay {
+    background-color: #252525;
+}
+.dark.dark-25 .watchpage-frame-items ytm15-watch {
+    background-color: #252525;
+}
+@media (min-width: 800px) and (min-device-width: 550px) and (orientation: landscape) {
+    .dark.dark-25 .watchpage-frame-items ytm15-watch::after {
+        background-color: #252525;
+    }
+}
+.dark.dark-25 ytm15-channels-header {
+    background-color: #222222;
+}
+.dark.dark-25 .playlist-header-container {
+    background-color: #222222;
+}
+.dark.dark-25 dialog.ytm15-dialog {
+    background-color: #252525;
+}
+.dark.dark-25 [data-viewing-replies="true"]>ytm15-comment {
+    background-color: #232323;
+}
+.dark.dark-25 .transparent-text {
+    color:#252525;
 }
 
 /* Dark 21 */
@@ -5737,6 +5866,9 @@ html.dark.dark-21 {
 }
 .dark.dark-21 [data-viewing-replies="true"]>ytm15-comment {
     background-color: #191919;
+}
+.dark.dark-21 .transparent-text {
+    color:#212121;
 }
 
 /* Global dark theme for dematerialized/2013 UI */

--- a/app/2015ytm.js
+++ b/app/2015ytm.js
@@ -146,8 +146,31 @@ PIVOT_HIDE_NOTIFICATIONS_expflag = localStorage.getItem("PIVOT_HIDE_NOTIFICATION
 PIVOT_NOTIFICATIONS_IS_ACTIVITY_expflag = localStorage.getItem("PIVOT_NOTIFICATIONS_IS_ACTIVITY");
 APP_HELVETICA_NEUE_FONT_expflag = localStorage.getItem("APP_HELVETICA_NEUE_FONT");
 APP_NEW_ERROR_SCREEN_expflag = localStorage.getItem("APP_NEW_ERROR_SCREEN");
+APP_CUSTOM_INVIDIOUS_URL_expflag = localStorage.getItem("APP_CUSTOM_INVIDIOUS_URL");
+if (APP_CUSTOM_INVIDIOUS_URL_expflag == undefined) {
+  localStorage.setItem("APP_CUSTOM_INVIDIOUS_URL", "https://api.allorigins.win/raw?url=https://yt.omada.cafe/");
+  APP_CUSTOM_INVIDIOUS_URL_expflag = localStorage.getItem("APP_CUSTOM_INVIDIOUS_URL");
+}
+APP_DONT_AUTH_TO_INVIDIOUS_expflag = localStorage.getItem("APP_DONT_AUTH_TO_INVIDIOUS");
+if (APP_DONT_AUTH_TO_INVIDIOUS_expflag == undefined) {
+  localStorage.setItem("APP_DONT_AUTH_TO_INVIDIOUS", "true");
+  APP_DONT_AUTH_TO_INVIDIOUS_expflag = localStorage.getItem("APP_DONT_AUTH_TO_INVIDIOUS");
+}
+APP_NO_ANDROID_ANIMATIONS_expflag = localStorage.getItem("APP_NO_ANDROID_ANIMATIONS");
+WEB_IOS_SPINNER_expflag = localStorage.getItem("WEB_IOS_SPINNER");
+HEADER_NO_SHADOW_expflag = localStorage.getItem("HEADER_NO_SHADOW");
+DARK_THEME_SEPERATE_BACKGROUND_COLOR_expflag = localStorage.getItem("DARK_THEME_SEPERATE_BACKGROUND_COLOR");
+APP_UNDERLINE_BUTTONS_expflag = localStorage.getItem("APP_UNDERLINE_BUTTONS");
+HEADER_CAST_BUTTON_AS_URL_BOX_expflag = localStorage.getItem("HEADER_CAST_BUTTON_AS_URL_BOX");
+HEADER_CAST_ALTERNATE_ICON_expflag = localStorage.getItem("HEADER_CAST_ALTERNATE_ICON");
+APP_STOP_TEXT_SELECTION_expflag = localStorage.getItem("APP_STOP_TEXT_SELECTION");
+if (APP_STOP_TEXT_SELECTION_expflag == undefined) {
+  localStorage.setItem("APP_STOP_TEXT_SELECTION", "true");
+  APP_STOP_TEXT_SELECTION_expflag = localStorage.getItem("APP_STOP_TEXT_SELECTION");
+}
+
 newErrorHtml = `<button class="error-content" onClick="location.reload();">
-<img class="error-icon ytm15-img" src="alert_error.png"></img><br>
+<div class="transparent-text" style="border-radius:50%;background: #c1c1c1;display: inline-block;width: 3.5rem;/*! padding: 10px; */font-size: 30px;font-weight: 500;height: 3.5rem;text-align: center;vertical-align: unset;margin-bottom: 1rem;">!</div><br>
 <span class="error-text">Error loading<br>Tap to retry</span>
 </div></button>`;
 if (PIVOT_SHRINK_SPACING_expflag == undefined) {
@@ -214,6 +237,9 @@ if (DARK_THEME_HASH_COLOR_expflag == "#30") {
 } else if (DARK_THEME_HASH_COLOR_expflag == "#28") {
     documentHTML.classList.add("dark-28");
     documentHTML.classList.remove("dark-21");
+} else if (DARK_THEME_HASH_COLOR_expflag == "#25") {
+    documentHTML.classList.add("dark-25");
+    documentHTML.classList.remove("dark-21");
 } else if (DARK_THEME_HASH_COLOR_expflag == "#21") {
     documentHTML.classList.remove("dark-28");
     documentHTML.classList.add("dark-21");
@@ -266,6 +292,42 @@ if (APP_NEW_ERROR_SCREEN_expflag == "true") {
 } else {
   documentHTML.classList.remove("tap-to-retry");
 }
+
+if (APP_NO_ANDROID_ANIMATIONS_expflag == "true") {
+  documentHTML.classList.add("no-animations");
+} else {
+  documentHTML.classList.remove("no-animations");
+}
+
+if (WEB_IOS_SPINNER_expflag == "true") {
+  documentHTML.classList.add("ios-spinner");
+} else {
+  documentHTML.classList.remove("ios-spinner");
+}
+
+if (HEADER_NO_SHADOW_expflag == "true") {
+  documentHTML.classList.add("header-no-shadow");
+} else {
+  documentHTML.classList.remove("header-no-shadow");
+}
+
+if (DARK_THEME_SEPERATE_BACKGROUND_COLOR_expflag == "true") {
+  documentHTML.classList.add("seperate-dark-color");
+} else {
+  documentHTML.classList.remove("seperate-dark-color");
+}
+
+if (APP_UNDERLINE_BUTTONS_expflag == "true") {
+  documentHTML.classList.add("underline");
+} else {
+  documentHTML.classList.remove("underline");
+}
+
+if (APP_STOP_TEXT_SELECTION_expflag == "true") {
+  documentHTML.classList.add("text-selection");
+} else {
+  documentHTML.classList.remove("text-selection");
+}
 };
 
 localStorageChange();
@@ -301,7 +363,7 @@ metaColorElm.content = "#000000";
 }
 }
 
-APIbaseURL = "https://invidious.nerdvpn.de/";
+APIbaseURL = APP_CUSTOM_INVIDIOUS_URL_expflag//"https://invidious.nerdvpn.de/";
 APIbaseURLWatch = "https://inv.nadeko.net/";
 APIbaseURLNew = "https://yt-api.p.rapidapi.com/";
 APIbaseURLPiped = "https://pipedapi.leptons.xyz/";

--- a/app/2015ytm.js
+++ b/app/2015ytm.js
@@ -630,7 +630,7 @@ dataModeChange();
 renderHeader();
 
 function renderCommentSection(parent, mediaType, cmSource, isCMPage, comntId, comntContinuation){
-    var cmBaseAPIURL = 'https://invidious.nerdvpn.de/api/v1/comments/';
+    var cmBaseAPIURL = APP_CUSTOM_INVIDIOUS_URL_expflag + 'api/v1/comments/';//'https://invidious.nerdvpn.de/api/v1/comments/';
 
     const commentSection = document.createElement("div");
     commentSection.classList.add("comment-section");
@@ -694,7 +694,7 @@ function renderCommentSection(parent, mediaType, cmSource, isCMPage, comntId, co
 
     const getCommentsData = new XMLHttpRequest();
     getCommentsData.open('GET', cmBaseAPIURL + cmSource + "?continuation=" + continuation, true);
-    getCommentsData.setRequestHeader('Authorization','Basic eXRtMTU6SlFKNTNLckxBRVk2RTVxaGdjbTM4UGtTenczYlpYbWs=');
+    if (APP_DONT_AUTH_TO_INVIDIOUS_expflag == "false"){getCommentsData.setRequestHeader('Authorization','Basic eXRtMTU6SlFKNTNLckxBRVk2RTVxaGdjbTM4UGtTenczYlpYbWs=');};
 
     getCommentsData.onerror = function(event) {
     console.error("An error occurred with this operation (" + getCommentsData.status + ")");

--- a/app/Material Spinner/spinner.js
+++ b/app/Material Spinner/spinner.js
@@ -1,11 +1,19 @@
 function spinner() {
   var spinner = document.createElement("div");
   spinner.classList.add("spinner-container");
-  spinner.innerHTML = `
-  <svg class="spinner" width="45px" height="45px" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">
-   <circle class="path" fill="none" stroke-width="6" stroke-linecap="spuare" cx="33" cy="33" r="30"></circle>
-</svg>
-  `;
+  if (localStorage.getItem("WEB_IOS_SPINNER") == "true") {
+    spinner.innerHTML = `
+    <svg class="spinner" width="30px" height="30px" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">
+    <circle class="path" fill="none" stroke-width="7" stroke-linecap="spuare" cx="33" cy="33" r="30"></circle>
+    </svg>
+    `;
+  } else {
+    spinner.innerHTML = `
+    <svg class="spinner" width="45px" height="45px" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">
+    <circle class="path" fill="none" stroke-width="6" stroke-linecap="spuare" cx="33" cy="33" r="30"></circle>
+    </svg>
+    `;
+  }
   spinnerParent.appendChild(spinner);
   if (spinnerParent === document.querySelector("#app")) {
   spinner.classList.add("full-height");

--- a/app/header.js
+++ b/app/header.js
@@ -203,9 +203,60 @@ function renderHeader() {
     headerEP.remove();
     }
     });
+    var openUrl = async function() {
+        let url = null;
+        try {
+            const regex = /(?:youtube\.com\/(?:.*[?&]v=|v\/|embed\/|.*\/)|youtu\.be\/)([A-Za-z0-9_-]{11})/;
+            const text = await navigator.clipboard.readText();
+            console.log(text);
+            const match = text.match(regex);
+            url = (match ? match[1] : null); // "NLqAF9hrVbY"
+            console.log(url);
+        } catch (err) {
+            console.log('Could not read clipboard: ' + err);
+        };
+
+        if (!app.querySelector("#watchpageFrame_Container")) {
+            app.insertAdjacentElement("afterbegin", watchContainer);
+        };
+        if (watchContainer.classList.contains("miniplayer")) {
+            watchContainer.classList.remove("miniplayer");
+            app.classList.remove("has-miniplayer");
+            watchFrame.scrolling = "yes";
+        };
+        watchFrame.src = "watch.html?v=" + url;
+        playerPrevVideoId = [""];
+        playerVideoId = url;
+        /* playerFrame.src = playerEmbedURL + playerVideoId + playerEmbedURLEnd; */
+        playerFrame.src = playerEmbedURLYT + playerVideoId + playerEmbedURLYTEnd;
+        console.log(ytm15Watch);
+        renderWatchPage(ytm15Watch);
+    };
 
     const headerButtons = document.createElement("div");
     headerButtons.classList.add("header-buttons");
+
+    const castBtn = document.createElement("button");
+    castBtn.classList.add("icon-button", "header-button", "search-button");
+    castBtn.onclick = function(){openUrl();};
+    castBtn.setAttribute("aria-label", SearchYT_text_string);
+    castBtn.setAttribute("aria-haspopup", "false");
+    let alternateIcon = `<path data-glyph="cast-connected" d="M448,384 M21,235 v-43 q52,0,96.5,-26 t70,-70 t25.5,-96 h43 q0,64,-31.5,118 t-85.5,85.5 t-118,31.5 M21,149 v-42 q29,0,53.5,-14.5 t39,-39 t14.5,-53.5 h43 q0,30,-11.5,57.5 t-32.5,48.5 t-48.5,32 t-57.5,11 M21,64 v-64 h64 q0,27,-18.5,45.5 t-45.5,18.5 Z"/>`
+    if (HEADER_CAST_ALTERNATE_ICON_expflag == "true") {alternateIcon = `<path data-glyph="cast-connected" fill="#919191" d="M448,384 M21,235 v-43 q52,0,96.5,-26 t70,-70 t25.5,-96 h43 q0,64,-31.5,118 t-85.5,85.5 t-118,31.5 M405,299 h-298 v-35 q63,-21,110.5,-68 t67.5,-111 h120 v214 M21,149 v-42 q29,0,53.5,-14.5 t39,-39 t14.5,-53.5 h43 q0,30,-11.5,57.5 t-32.5,48.5 t-48.5,32 t-57.5,11 M21,64 v-64 h64 q0,27,-18.5,45.5 t-45.5,18.5 Z"/>`}
+    castBtn.innerHTML = `<ytm15-icon class="search-icon"><svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 64.7273 512 448.462"><g transform="scale(1,-1) translate(0, -480.36365)"><path data-glyph="cast-connected" d="M448,384 h-384 q-18,0,-30.5,-12.5 t-12.5,-30.5 v-64 h43 v64 h384 v-298 h-149 v-43 h149 q18,0,30.5,12.5 t12.5,30.5 v298 q0,18,-12.5,30.5 t-30.5,12.5"/>` + alternateIcon + `</g></svg></ytm15-icon>`;
+    if (window.location.pathname.split("/").slice(3, 4) == "results.html") {
+        castBtn.setAttribute("hidden", "");
+    }
+    if (window.location.hash.split("/").join(',').split("?").join(',').split(',').slice(1, 2)[0] == "results" || window.location.pathname.split("/").slice(3, 4) == "settings.html" || window.location.pathname.split("/").slice(3, 4) == "settings" || window.location.pathname.split("/").slice(2, 3) == "settings.html" || window.location.pathname.split("/").slice(2, 3) == "settings") {
+        castBtn.setAttribute("hidden", "");
+    }
+    window.addEventListener('hashchange', function (event) {
+        if (window.location.hash.split("/").join(',').split("?").join(',').split(',').slice(1, 2)[0] == "results" || window.location.pathname.split("/").slice(3, 4) == "settings.html" || window.location.pathname.split("/").slice(3, 4) == "settings" || window.location.pathname.split("/").slice(2, 3) == "settings.html" || window.location.pathname.split("/").slice(2, 3) == "settings") {
+            castBtn.setAttribute("hidden", "");
+        } else {
+            castBtn.removeAttribute("hidden", "");
+        }
+    });
 
     const searchBtn = document.createElement("button");
     searchBtn.classList.add("icon-button", "header-button", "search-button");
@@ -345,6 +396,7 @@ function renderHeader() {
     header.appendChild(headerCont);
     headerCont.appendChild(headerTitle);
     headerCont.appendChild(headerButtons);
+    if (HEADER_CAST_BUTTON_AS_URL_BOX_expflag == "true") {headerButtons.appendChild(castBtn);};
     headerButtons.appendChild(searchBtn);
     headerButtons.appendChild(menuBtn);
 

--- a/app/home.js
+++ b/app/home.js
@@ -160,7 +160,7 @@ function renderData() {
         /* getHomeData.open('GET', APIbaseURL + 'api/v1/trending?type=' + trendType, true); */
         getHomeData.open('GET', APIbaseURL + 'api/v1/trending?type=' + window.location.hash.split("?").slice(1, 2).toString().split("&").slice(0, 1).toString().split("trtype").slice(1, 2).toString().split("=").slice(1, 2).toString(), true);
         }
-        getHomeData.setRequestHeader('Authorization','Basic eXRtMTU6SlFKNTNLckxBRVk2RTVxaGdjbTM4UGtTenczYlpYbWs=');
+        if (APP_DONT_AUTH_TO_INVIDIOUS_expflag == "false"){getHomeData.setRequestHeader('Authorization','Basic eXRtMTU6SlFKNTNLckxBRVk2RTVxaGdjbTM4UGtTenczYlpYbWs=');};
 
         getHomeData.onerror = function(event) {
         console.error("An error occurred with this operation (" + getHomeData.status + ")");
@@ -290,7 +290,7 @@ function renderData() {
         const getHomeData1 = new XMLHttpRequest();
 
         getHomeData1.open('GET', APIbaseURL + 'api/v1/popular', true);
-        getHomeData1.setRequestHeader('Authorization','Basic eXRtMTU6SlFKNTNLckxBRVk2RTVxaGdjbTM4UGtTenczYlpYbWs=');
+        if (APP_DONT_AUTH_TO_INVIDIOUS_expflag == "false"){getHomeData1.setRequestHeader('Authorization','Basic eXRtMTU6SlFKNTNLckxBRVk2RTVxaGdjbTM4UGtTenczYlpYbWs=');};
 
         getHomeData1.onerror = function(event) {
         console.error("An error occurred with this operation (" + getHomeData1.status + ")");
@@ -424,7 +424,7 @@ function renderData() {
     const getHomeData3 = new XMLHttpRequest();
 
     getHomeData3.open('GET', APIbaseURL + 'api/v1/popular', true);
-    getHomeData3.setRequestHeader('Authorization','Basic eXRtMTU6SlFKNTNLckxBRVk2RTVxaGdjbTM4UGtTenczYlpYbWs=');
+    if (APP_DONT_AUTH_TO_INVIDIOUS_expflag == "false"){getHomeData3.setRequestHeader('Authorization','Basic eXRtMTU6SlFKNTNLckxBRVk2RTVxaGdjbTM4UGtTenczYlpYbWs=');};
 
     getHomeData3.onerror = function(event) {
         console.error("An error occurred with this operation (" + getHomeData3.status + ")");
@@ -626,7 +626,7 @@ function renderDataTrending(homeShelfTrendingType, shelfTitle) {
     } else if (window.location.hash.split("/").join(',').split("?").join(',').split(',').slice(1, 2)[0] == "trending") {
     getHomeData2.open('GET', APIbaseURL + 'api/v1/trending?type=' + trendType, true);
     }
-    getHomeData2.setRequestHeader('Authorization','Basic eXRtMTU6SlFKNTNLckxBRVk2RTVxaGdjbTM4UGtTenczYlpYbWs=');
+    if (APP_DONT_AUTH_TO_INVIDIOUS_expflag == "false"){getHomeData2.setRequestHeader('Authorization','Basic eXRtMTU6SlFKNTNLckxBRVk2RTVxaGdjbTM4UGtTenczYlpYbWs=');};
 
     getHomeData2.onerror = function(event) {
     console.error("An error occurred with this operation (" + getHomeData2.status + ")");

--- a/app/settings.js
+++ b/app/settings.js
@@ -46,6 +46,50 @@ function renderSettingOptionMenu(parent, somTitle, somSubtitle, somArray, somLSI
 
     parent.appendChild(settingOptionMenu);
 }
+// NEW: Render a setting allowing text input
+function renderSettingText(parent, stTitle, stSubtitle, stValue, stPlaceholder, stDisabled, stLSItem) {
+  const settingText = document.createElement("div");
+  settingText.classList.add("setting-text", "has-ripple");
+  const sbLabel = document.createElement("label");
+  sbLabel.classList.add("setting-label");
+  const settingTitleSubBlock = document.createElement("div");
+  settingTitleSubBlock.classList.add("setting-title-subtitle-block");
+  const settingTitle = document.createElement("h3");
+  settingTitle.id = "setting-title-subtitle-block-title";
+  settingTitle.innerHTML = stTitle;
+  const settingSubtitle = document.createElement("span");
+  settingSubtitle.id = "setting-title-subtitle-block-subtitle";
+  settingSubtitle.innerHTML = stSubtitle;
+
+  // Text input element
+  const textInput = document.createElement("input");
+  textInput.type = "text";
+  textInput.classList.add("setting-text-input");
+  textInput.value = stValue || "";
+  if (stPlaceholder) textInput.placeholder = stPlaceholder;
+  if (stDisabled) textInput.disabled = true;
+
+  // Local Storage logic for text input
+  textInput.addEventListener("input", function() {
+    if (stLSItem) {
+      localStorage.setItem(stLSItem, textInput.value);
+    }
+  });
+
+  // Load stored value if exists
+  if (stLSItem) {
+    const stored = localStorage.getItem(stLSItem);
+    if (stored !== null) textInput.value = stored;
+  }
+
+  settingText.appendChild(sbLabel);
+  sbLabel.appendChild(settingTitleSubBlock);
+  settingTitleSubBlock.appendChild(settingTitle);
+  settingTitleSubBlock.appendChild(settingSubtitle);
+  sbLabel.appendChild(textInput);
+
+  parent.appendChild(settingText);
+}
 
 function settingsPage() {
     pageCont.innerHTML = "";
@@ -191,6 +235,9 @@ function settingsPage() {
       };
       renderSettingOptionMenu(settingsPage, item.title, optSubtitle);
       };
+      if (item.type == "text") {
+        renderSettingText(settingsPage, item.title, item.subtitle, item.value, item.placeholder, item.disabled, item.lsitem);
+      }
       });
       }
       if (window.location.hash.split("/").join(',').split("?").join(',').split(',').slice(1, 2)[0] == "expflags") {
@@ -406,6 +453,11 @@ function settingsPage() {
           "selected-default": false
         },
         {
+          "title": "#25",
+          "selected": DARK_THEME_HASH_COLOR_expflag == "#25",
+          "selected-default": false
+        },
+        {
           "title": "#21",
           "selected": DARK_THEME_HASH_COLOR_expflag == "#21",
           "selected-default": false
@@ -579,6 +631,96 @@ function settingsPage() {
         "pressed-default": false,
         "disabled": false,
         "lsitem": "APP_NEW_ERROR_SCREEN"
+      },
+      {
+        "type": "text",
+        "title": "APP_CUSTOM_INVIDIOUS_URL",
+        "subtitle": "This loads your home page and comments. <small>which should update and not be static</small><br>If you have your own invidious instance put it here<br>You should change CORS policy if you own your instance, otherwise use a CORS redirector",
+        "value": "https://api.allorigins.win/raw?url=https://yt.omada.cafe/",
+        "placeholder": "",
+        "disabled": false,
+        "lsitem": "APP_CUSTOM_INVIDIOUS_URL"
+      },
+      {
+        "type": "boolean",
+        "title": "APP_DONT_AUTH_TO_INVIDIOUS",
+        "subtitle": "",
+        "pressed": APP_DONT_AUTH_TO_INVIDIOUS_expflag == "true",
+        "pressed-default": true,
+        "disabled": false,
+        "lsitem": "APP_DONT_AUTH_TO_INVIDIOUS"
+      },
+      {
+        "type": "boolean",
+        "title": "APP_NO_ANDROID_ANIMATIONS",
+        "subtitle": "",
+        "pressed": APP_NO_ANDROID_ANIMATIONS_expflag == "true",
+        "pressed-default": false,
+        "disabled": false,
+        "lsitem": "APP_NO_ANDROID_ANIMATIONS"
+      },
+      {
+        "type": "boolean",
+        "title": "WEB_IOS_SPINNER",
+        "subtitle": "",
+        "pressed": WEB_IOS_SPINNER_expflag == "true",
+        "pressed-default": false,
+        "disabled": false,
+        "lsitem": "WEB_IOS_SPINNER"
+      },
+      {
+        "type": "boolean",
+        "title": "HEADER_NO_SHADOW",
+        "subtitle": "",
+        "pressed": HEADER_NO_SHADOW_expflag == "true",
+        "pressed-default": false,
+        "disabled": false,
+        "lsitem": "HEADER_NO_SHADOW"
+      },
+      {
+        "type": "boolean",
+        "title": "DARK_THEME_SEPERATE_BACKGROUND_COLOR",
+        "subtitle": "",
+        "pressed": DARK_THEME_SEPERATE_BACKGROUND_COLOR_expflag == "true",
+        "pressed-default": false,
+        "disabled": false,
+        "lsitem": "DARK_THEME_SEPERATE_BACKGROUND_COLOR"
+      },
+      {
+        "type": "boolean",
+        "title": "APP_UNDERLINE_BUTTONS",
+        "subtitle": "",
+        "pressed": APP_UNDERLINE_BUTTONS_expflag == "true",
+        "pressed-default": false,
+        "disabled": false,
+        "lsitem": "APP_UNDERLINE_BUTTONS"
+      },
+      {
+        "type": "boolean",
+        "title": "HEADER_CAST_BUTTON_AS_URL_BOX",
+        "subtitle": "Copy a youtube link and press cast to open it in YTm15",
+        "pressed": HEADER_CAST_BUTTON_AS_URL_BOX_expflag == "true",
+        "pressed-default": false,
+        "disabled": false,
+        "lsitem": "HEADER_CAST_BUTTON_AS_URL_BOX"
+      },
+      {
+        "type": "boolean",
+        "title": "HEADER_CAST_ALTERNATE_ICON",
+        "subtitle": "",
+        "pressed": HEADER_CAST_ALTERNATE_ICON_expflag == "true",
+        "pressed-default": false,
+        "disabled": false,
+        "lsitem": "HEADER_CAST_ALTERNATE_ICON"
+      },
+      {
+        "type": "boolean",
+        "title": "APP_STOP_TEXT_SELECTION",
+        "subtitle": "",
+        "pressed": APP_STOP_TEXT_SELECTION_expflag == "true",
+        "pressed-default": true,
+        "disabled": false,
+        "lsitem": "APP_STOP_TEXT_SELECTION"
       }
       ];
       settingBlocks.forEach(function(item){
@@ -596,6 +738,9 @@ function settingsPage() {
       };
       renderSettingOptionMenu(settingsPage, item.title, optSubtitle, item.options, item.lsitem);
       };
+      if (item.type == "text") {
+        renderSettingText(settingsPage, item.title, item.subtitle, item.value, item.placeholder, item.disabled, item.lsitem);
+      }
       });
       }
     } else {

--- a/app/watch.js
+++ b/app/watch.js
@@ -26,7 +26,7 @@ function renderWatchPage(parent) {
     /* getWatchData.open('GET', APIbaseURL + 'api/v1/videos/' + playerVideoId, true); */
     /* getWatchData.open('GET', APIbaseURLWatch + 'api/v1/videos/' + playerVideoId, true); */
     /* getWatchData.setRequestHeader('Authorization','Basic eXRtMTU6SlFKNTNLckxBRVk2RTVxaGdjbTM4UGtTenczYlpYbWs='); */
-    getWatchData.open('GET', APIbaseURLNew + 'video/info?extend=1&geo=us&id=' + playerVideoId, true);
+    getWatchData.open('GET', APIbaseURLNew + 'video/info?extend=1&geo=US&id=' + playerVideoId, true);
     getWatchData.setRequestHeader('x-rapidapi-key', '4b0791fe33mshce00ad033774274p196706jsn957349df7a8f');
     getWatchData.setRequestHeader('x-rapidapi-host', 'yt-api.p.rapidapi.com');
 


### PR DESCRIPTION
These add 10 expflags:

- **APP_CUSTOM_INVIDIOUS_URL**: Since there are so many instances closing their API and setting up anubis or cloudflare to stop any interaction you can put your own instance here if you have one. I found one remaining API so I put a default. This also added text box expflags if you want to use those
- **APP_DONT_AUTH_TO_INVIDIOUS**: Don't put authorization header when accessing the above API, because the default i use rejects requests with authorization headers
- **APP_NO_ANDROID_ANIMATIONS**: Tries to add iOS animations, meaning remove most fade in animations and add a (bad) sliding effect to (some) pages.
- **WEB_IOS_SPINNER**: Shrinks the spinner and makes it grey like in iOS.
- **HEADER_NO_SHADOW**: Seen in YouTube v13 iOS versions
- **DARK_THEME_SEPERATE_BACKGROUND_COLOR** Also seen in YouTube v13 iOS versions
  - #252525 color for DARK_THEME_HASH_COLOR, you guessed it, seen in YouTube v13 iOS versions
- **APP_UNDERLINE_BUTTONS**: Seen on, atleast my install of v13 YouTube. I haven't seen anybody with this but I saw it in person so it exists
- **HEADER_CAST_BUTTON_AS_URL_BOX**: Lets you copy a youtube URL and quickly open it. Cast button because it's more _i m m e r s i v e_. Although I couldn't find a v10 icon so there's a v11 icon
- **HEADER_CAST_ALTERNATE_ICON**: Seen in YouTube v13 iOS versions
- **APP_STOP_TEXT_SELECTION**: Self explanatory

Also fixed the video details page (2 character fix) oh and comments and home page should finally load now!

@Yacine-Book @ytm15