### PR TITLE
Removal of Omada as designated Invidious Instance

### DIFF
--- a/app/2015ytm.js
+++ b/app/2015ytm.js
@@ -148,7 +148,7 @@ APP_HELVETICA_NEUE_FONT_expflag = localStorage.getItem("APP_HELVETICA_NEUE_FONT"
 APP_NEW_ERROR_SCREEN_expflag = localStorage.getItem("APP_NEW_ERROR_SCREEN");
 APP_CUSTOM_INVIDIOUS_URL_expflag = localStorage.getItem("APP_CUSTOM_INVIDIOUS_URL");
 if (APP_CUSTOM_INVIDIOUS_URL_expflag == undefined) {
-  localStorage.setItem("APP_CUSTOM_INVIDIOUS_URL", "https://api.allorigins.win/raw?url=https://yt.omada.cafe/");
+  localStorage.setItem("APP_CUSTOM_INVIDIOUS_URL", "NULL");
   APP_CUSTOM_INVIDIOUS_URL_expflag = localStorage.getItem("APP_CUSTOM_INVIDIOUS_URL");
 }
 APP_DONT_AUTH_TO_INVIDIOUS_expflag = localStorage.getItem("APP_DONT_AUTH_TO_INVIDIOUS");

--- a/app/settings.js
+++ b/app/settings.js
@@ -636,7 +636,7 @@ function settingsPage() {
         "type": "text",
         "title": "APP_CUSTOM_INVIDIOUS_URL",
         "subtitle": "This loads your home page and comments. <small>which should update and not be static</small><br>If you have your own invidious instance put it here<br>You should change CORS policy if you own your instance, otherwise use a CORS redirector",
-        "value": "https://api.allorigins.win/raw?url=https://yt.omada.cafe/",
+        "value": "",
         "placeholder": "",
         "disabled": false,
         "lsitem": "APP_CUSTOM_INVIDIOUS_URL"


### PR DESCRIPTION
Hello, I am a member of the Omada Collective, you can verify this by going to https://omada.cafe/contact [https://omada.cat/key.txt] and or https://atf.omada.cat. We've been made aware that this and other projects have used our invidious service without our permission. The traffic generated by these projects has put stress on our invidious instance, we are now asking these projects to stop using our instance, as we want to make sure our services are first available to our users and clients, before non-omada traffic makes our service unavailable to our users. 